### PR TITLE
update foia.md

### DIFF
--- a/foia.md
+++ b/foia.md
@@ -6,7 +6,8 @@ permalink: /foia/
 
 ### Accesso Civico Generalizzato (FOIA)
 
-Con questa semplice pagina puoi richiedere ufficialmente il dataset dei catasti delle terre bruciate del tuo comune. E' importante perchè in questo modo sensibilizziamo le Pubbliche Amministrazioni ad informare correttamente su quali siano gli incendi avvenuti attorno a noi. Aiutaci a richiedere i dati del tuo comune o di un comune a cui sei interessato! Contiamo su di te!
+Con questa semplice pagina puoi richiedere ufficialmente il dataset dei catasti delle terre bruciate del tuo comune. E' importante perchè in questo modo sensibilizziamo le Pubbliche Amministrazioni ad informare correttamente su quali siano gli incendi avvenuti attorno a noi. Ma soprattutto le invitiamo ad applicare esattamente l’art 10 comma 2 della Legge 353/2000 chiedendo l'elenco con relative perimetrazioni dei soprassuoli già percorsi dal fuoco nell'ultimo quinquennio. Una legge poco applicata ma molto incisiva quale deterrente alle possibili speculazioni post-incendio, visti i vincoli resi applicabili solo in caso di definizione ed aggiornamento del catasto incendi.
+Aiutaci a richiedere i dati del tuo comune o di un comune a cui sei interessato! Contiamo su di te!
 Seleziona il comune a cui vuoi inviare la richiesta. Verrai ridirezionato al modulo online da compilare con i tuoi dati per l'invio della comunicazione in modo ufficiale.
 
 <form>


### PR DESCRIPTION
Aggiunto paragrafo per chiarire l'importanza della definizione del catasto incendi e la ratio della norma quale deterrente alle possibili speculazioni. Il testo aggiunto è il seguente:
"Ma soprattutto le invitiamo ad applicare esattamente l’art 10 comma 2 della Legge 353/2000 chiedendo l'elenco con relative perimetrazioni dei soprassuoli già percorsi dal fuoco nell'ultimo quinquennio. Una legge poco applicata ma molto incisiva quale deterrente alle possibili speculazioni post-incendio visti i vincoli resi applicabili proprio solo in caso di definizione ed aggiornamento del catasto incendi."